### PR TITLE
Cover redirect pattern

### DIFF
--- a/libexec/hsenv-install
+++ b/libexec/hsenv-install
@@ -35,7 +35,7 @@ mkdir -p $HSENV_ROOT/cache $build_dir $build_dir/ghc $build_dir/cabal-install
 # Download and install GHC
 download="http://www.haskell.org/ghc/dist/$version/ghc-$version-$arch-$platform.tar.bz2"
 ghc_cache_file="$HSENV_ROOT/cache/ghc-$version-$arch-$platform.tar.bz2"
-curl -sfC - -o $ghc_cache_file $download ||:
+curl -sfC - -L -o $ghc_cache_file $download ||:
 cd $build_dir/ghc
 tar jxf $ghc_cache_file --strip-components 1
 ./configure --prefix=$version_dir


### PR DESCRIPTION
Cover Redirect pattern

before

```
$ hsenv install 7.8.4
tar: Unrecognized archive format
tar: Error exit delayed from previous errors.

$  cat ghc-7.8.4-x86_64-apple-darwin.tar.bz2 
<html>
<head><title>302 Found</title></head>
<body bgcolor="white">
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.8.0</center>
</body>
</html>

$ ls -lh ghc-7.8.4-x86_64-apple-darwin.tar.bz2
-rw-r--r--  1 surume  staff   153B  8  9 05:25 ghc-7.8.4-x86_64-apple-darwin.tar.bz2
```

after

```
$ hsenv install 7.8.4
$ ls -lh ghc-7.8.4-x86_64-apple-darwin.tar.bz2
-rw-r--r--  1 surume  staff   124M  8  9 05:30 ghc-7.8.4-x86_64-apple-darwin.tar.bz2
```
